### PR TITLE
Fix tests to be able to run with `zope.component >= 5`.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ CHANGES
 
 - Drop support for Python 3.4.
 
+- Fix tests to be able to run with ``zope.component >= 5``.
+
 
 3.0.1 (2018-01-12)
 ==================

--- a/src/grokcore/catalog/tests/functional/catalog/catalog.py
+++ b/src/grokcore/catalog/tests/functional/catalog/catalog.py
@@ -3,7 +3,7 @@ Let's setup a site in which we manage a couple of objects:
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 Now we add some indexable objects to the site:
@@ -30,6 +30,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 """
 

--- a/src/grokcore/catalog/tests/functional/catalog/catalog.py
+++ b/src/grokcore/catalog/tests/functional/catalog/catalog.py
@@ -30,7 +30,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 """
 

--- a/src/grokcore/catalog/tests/functional/catalog/indexes.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes.py
@@ -58,7 +58,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes.py
@@ -6,7 +6,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 Now we add some indexable objects to the site::
@@ -58,6 +58,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_app_interface.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_app_interface.py
@@ -53,7 +53,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 """
 
 import grokcore.site

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_app_interface.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_app_interface.py
@@ -7,7 +7,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 We are able to find the catalog::
@@ -53,6 +53,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 """
 
 import grokcore.site

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_attribute.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_attribute.py
@@ -38,7 +38,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 """
 
 import grokcore.site

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_attribute.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_attribute.py
@@ -8,7 +8,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 Now we add some indexable objects to the site::
@@ -38,6 +38,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 """
 
 import grokcore.site

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_class.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_class.py
@@ -49,7 +49,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_class.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_class.py
@@ -7,7 +7,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 Now we add some indexable objects to the site::
@@ -49,6 +49,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_datetimeindex.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_datetimeindex.py
@@ -6,7 +6,7 @@ Let's set up a site in which we manage a couple of objects::
   >>> import datetime
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 Now we add some indexable objects to the site::
@@ -64,6 +64,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_datetimeindex.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_datetimeindex.py
@@ -64,7 +64,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_install_on.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_install_on.py
@@ -41,7 +41,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 """
 

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_install_on.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_install_on.py
@@ -5,7 +5,7 @@ any site::
 
 Let's set up a site in which we manage a couple of objects::
 
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
@@ -41,6 +41,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 """
 
@@ -48,7 +49,7 @@ import grokcore.site
 import grokcore.catalog
 from grokcore.content import Container
 from zope.interface import Interface, Attribute, implementer
-from zope.component.interfaces import ObjectEvent, IObjectEvent
+from zope.interface.interfaces import ObjectEvent, IObjectEvent
 
 
 class Herd(Container, grokcore.site.Site):

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_multiple.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_multiple.py
@@ -7,7 +7,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 We are able to query the catalog::
@@ -31,6 +31,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_multiple.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_multiple.py
@@ -31,7 +31,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_multiple_conflict.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_multiple_conflict.py
@@ -30,7 +30,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_multiple_conflict.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_multiple_conflict.py
@@ -12,7 +12,7 @@ Let's set up a site in which we manage a couple of objects::
     ...
   KeyError:...
 
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
   >>> from zope.catalog.interfaces import ICatalog
   >>> from zope.component import getUtility, queryUtility
@@ -30,6 +30,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_name.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_name.py
@@ -31,7 +31,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_name.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_name.py
@@ -7,7 +7,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
   >>> from zope.catalog.interfaces import ICatalog
@@ -31,6 +31,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_nonexistent.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_nonexistent.py
@@ -32,7 +32,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 """  # noqa: E501 line too long
 
 import grokcore.site

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_nonexistent.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_nonexistent.py
@@ -17,7 +17,7 @@ IGNORE_EXCEPTION_MODULE_IN_PYTHON2 normalizer)
 Nuke the catalog and intids in the end, so as not to confuse
 other tests::
 
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
   >>> from zope.catalog.interfaces import ICatalog
   >>> from zope.component import getUtility
@@ -32,6 +32,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 """  # noqa: E501 line too long
 
 import grokcore.site

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_set.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_set.py
@@ -5,7 +5,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 Now we add some indexable objects to the site::
@@ -42,6 +42,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_set.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_set.py
@@ -42,7 +42,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_site.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_site.py
@@ -30,7 +30,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 """
 
 import grokcore.site

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_site.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_site.py
@@ -7,7 +7,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 The catalog is there in the site::
@@ -30,6 +30,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 """
 
 import grokcore.site

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_valueindex.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_valueindex.py
@@ -44,7 +44,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/indexes_valueindex.py
+++ b/src/grokcore/catalog/tests/functional/catalog/indexes_valueindex.py
@@ -5,7 +5,7 @@ Let's set up a site in which we manage a couple of objects::
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 Now we add some indexable objects to the site::
@@ -44,6 +44,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 Unfortunately ftests don't have good isolation from each other yet.
 """

--- a/src/grokcore/catalog/tests/functional/catalog/setuporder.py
+++ b/src/grokcore/catalog/tests/functional/catalog/setuporder.py
@@ -33,7 +33,6 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
-  >>> setSite(None)
 
 """
 

--- a/src/grokcore/catalog/tests/functional/catalog/setuporder.py
+++ b/src/grokcore/catalog/tests/functional/catalog/setuporder.py
@@ -6,7 +6,7 @@ Let's setup a site in which we manage a couple of objects:
 
   >>> herd = Herd()
   >>> getRootFolder()['herd'] = herd
-  >>> from zope.site.hooks import setSite
+  >>> from zope.component.hooks import setSite
   >>> setSite(herd)
 
 Now we add some indexable objects to the site:
@@ -33,6 +33,7 @@ other tests::
   >>> intids = component.getUtility(IIntIds)
   >>> sm.unregisterUtility(intids, provided=IIntIds)
   True
+  >>> setSite(None)
 
 """
 

--- a/src/grokcore/catalog/tests/test_functional.py
+++ b/src/grokcore/catalog/tests/test_functional.py
@@ -3,14 +3,21 @@ import unittest
 from pkg_resources import resource_listdir
 
 from zope.app.appsetup.testlayer import ZODBLayer
+from zope.site.hooks import setSite
 from zope.testing import renormalizing
 
 import grokcore.catalog
 
 
-FunctionalLayer = ZODBLayer(grokcore.catalog)
+class CatalogZODBLayer(ZODBLayer):
+    """Custom ZODBLayer which also cleans up the site."""
+
+    def testTearDown(self):
+        setSite(None)
+        super(CatalogZODBLayer, self).testTearDown()
 
 
+FunctionalLayer = CatalogZODBLayer(grokcore.catalog)
 checker = renormalizing.RENormalizing()
 
 

--- a/src/grokcore/catalog/tests/test_functional.py
+++ b/src/grokcore/catalog/tests/test_functional.py
@@ -45,7 +45,3 @@ def test_suite():
     for name in ["catalog"]:
         suite.addTest(suiteFromPackage(name))
     return suite
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')


### PR DESCRIPTION
These changes where necessary to run again with zope.component 5.0 and zope.interface 5.3.0.
I am not sure why this is now necessary.

After fixing the import error which shows up in https://github.com/zopefoundation/grokcore.catalog/runs/2159617230?check_suite_focus=true I got the following traceback for nearly every test but the first one (in isolation (aka only running a single) the tests run fine.

```Python
File ".../grokcore.catalog/src/grokcore/catalog/tests/functional/catalog/indexes_datetimeindex.py", line 8, in grokcore.catalog.tests.functional.catalog.indexes_datetimeindex
Failed example:
    getRootFolder()['herd'] = herd
Exception raised:
    Traceback (most recent call last):
      File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/doctest.py", line 1336, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest grokcore.catalog.tests.functional.catalog.indexes_datetimeindex[2]>", line 1, in <module>
        getRootFolder()['herd'] = herd
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/container/btree.py", line 84, in __setitem__
        setitem(self, self._setitemf, key, value)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/container/contained.py", line 578, in setitem
        notify(event)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/event/__init__.py", line 32, in notify
        subscriber(event)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/component/event.py", line 27, in dispatch
        component_subscribers(event, None)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/component/_api.py", line 134, in subscribers
        return sitemanager.subscribers(objects, interface)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/interface/registry.py", line 448, in subscribers
        return self.adapters.subscribers(objects, provided)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/interface/adapter.py", line 899, in subscribers
        subscription(*objects)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/component/event.py", line 36, in objectEventNotify
        component_subscribers((event.object, event), None)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/component/_api.py", line 134, in subscribers
        return sitemanager.subscribers(objects, interface)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/interface/registry.py", line 448, in subscribers
        return self.adapters.subscribers(objects, provided)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/interface/adapter.py", line 899, in subscribers
        subscription(*objects)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/container/contained.py", line 159, in dispatchToSublocations
        subs = ISublocations(object, None)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/component/hooks.py", line 135, in adapter_hook
        return siteinfo.adapter_hook(interface, object, name, default)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/zope/interface/adapter.py", line 822, in _uncached_lookup
        if order >= len(byorder):
      File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/collections/__init__.py", line 1169, in __len__
        return len(self.data)
      File ".../grokcore.catalog/.tox/py39/lib/python3.9/site-packages/ZODB/Connection.py", line 785, in setstate
        raise ConnectionStateError(msg)
    ZODB.POSException.ConnectionStateError: Shouldn't load state for persistent.list.PersistentList 0x169944700e669f2b when the connection is closed
```

This was fixed by adding `setSite(None)` to every test as otherwise the previously used site manager gets the base for the new one. The previous site manager has a closed connection.

Is this just a bad test setup here or could it be a problem in one of the changes in `zope.component`?